### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "A CLI utility that reads a .env file before starting a process"
 license-file = "LICENSE.txt"
+repository = "https://github.com/JensGM/pushenv"
 
 [[bin]]
 name = "pushenv"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.